### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -1,5 +1,8 @@
 name: Jekyll site CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/digitalshah314/game-/security/code-scanning/2](https://github.com/digitalshah314/game-/security/code-scanning/2)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions used by this workflow to the minimum required. This workflow only needs to read the repository contents to allow `actions/checkout` to work; it does not need to write to the repository or interact with other resources. Therefore, the best fix is to add a top-level `permissions` block setting `contents: read`. Placing it at the root of the workflow (alongside `name` and `on`) will apply it to all jobs in the file without changing existing behavior.

Concretely, edit `.github/workflows/jekyll-docker.yml` and insert:

```yaml
permissions:
  contents: read
```

between the `name: Jekyll site CI` line and the `on:` block. No additional methods, imports, or definitions are needed, and no other parts of the workflow need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
